### PR TITLE
Fix small bugs around the directory/file install.

### DIFF
--- a/pgxnclient/commands/install.py
+++ b/pgxnclient/commands/install.py
@@ -96,7 +96,7 @@ class InstallUninstall(WithMake, WithSpecLocal, Command):
     def _run(self, dir):
         spec = self.get_spec()
         if spec.is_dir():
-            pdir = spec.dirname
+            pdir = os.path.abspath(spec.dirname)
         elif spec.is_file():
             pdir = self.unpack(spec.filename, dir)
         else:   # download

--- a/pgxnclient/utils/zip.py
+++ b/pgxnclient/utils/zip.py
@@ -62,7 +62,7 @@ def unpack(zipname, destdir):
     # directory, so return the first dir we found containing a Makefile,
     # alternatively just return the unpacked dir
     for dir in os.listdir(destdir):
-        for fn in ('Makefile', 'makefile', 'GNUmakefile'):
+        for fn in ('Makefile', 'makefile', 'GNUmakefile', 'configure'):
             if os.path.exists(os.path.join(destdir, dir, fn)):
                 return os.path.join(destdir, dir)
 


### PR DESCRIPTION
For the directory install, if the path is relative and the
extension expects to run configure, the path to configure
is bogus as the subprocess runs the extension directory.
For the file install, if the extension expects to run
configure before make, Makefile does not necessarily exit,
so discerning the extension's directory by any of 'Makefile',
'makefile' or 'GNUMakefile' was not enough.

---

I really need this change for the upcoming PGXN extension from my side.  Appreciate for your good work!
