### PR TITLE
Fix misspelling of spec variable name in missing META.json exception mes...

### DIFF
--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -384,7 +384,7 @@ indications, for instance 'pkgname=1.0', or 'pkgname>=2.1'.
             logger.debug("reading %s", fn)
             if not os.path.exists(fn):
                 raise PgxnClientException(
-                    _("file 'META.json' not found in '%s'") % dir)
+                    _("file 'META.json' not found in '%s'") % spec)
 
             with open(fn) as f:
                 return load_json(f)


### PR DESCRIPTION
When using pgxnclient to load a directory spec without a META.json file, I got the following error:

  File "/usr/lib/python2.6/site-packages/pgxnclient/commands/**init**.py", line 387, in get_meta
    _("file 'META.json' not found in '%s'") % dir)
UnboundLocalError: local variable 'dir' referenced before assignment

Replacing "dir" with "spec" fixes the issue: the directory is properly reported in the (expected) exception message.

Full stack trace below.

I briefly explored writing a test to cover this case, but I'm afraid my python is not up to snuff :/

Thanks for your work on this useful tool!

[vagrant@vagrant-centos-56-64 ~]$ sudo pgxn load -p 5432 -U postgres -d postgres --pg_config /some/path/to/pgsql/bin/pg_config   /some/path/to/pgvihash/
ERROR: unexpected error: UnboundLocalError - local variable 'dir' referenced before assignment
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/pgxnclient/cli.py", line 59, in script
    main(args)
  File "/usr/lib/python2.6/site-packages/pgxnclient/cli.py", line 31, in main
    run_command(opt, parser)
  File "/usr/lib/python2.6/site-packages/pgxnclient/commands/**init**.py", line 96, in run_command
    return opts.cmd(opts, parser=parser).run()
  File "/usr/lib/python2.6/site-packages/pgxnclient/commands/install.py", line 446, in run
    items = self._get_extensions()
  File "/usr/lib/python2.6/site-packages/pgxnclient/commands/install.py", line 404, in _get_extensions
    dist = self.get_meta(spec)
  File "/usr/lib/python2.6/site-packages/pgxnclient/commands/__init__.py", line 387, in get_meta
    _("file 'META.json' not found in '%s'") % dir)
UnboundLocalError: local variable 'dir' referenced before assignment
