### PR TITLE
Fix semver to comply hyphen style.

### DIFF
--- a/pgxnclient/utils/semver.py
+++ b/pgxnclient/utils/semver.py
@@ -125,7 +125,7 @@ re_semver = re.compile(r"""
         (0|[1-9][0-9]*)
     \.  (0|[1-9][0-9]*)
     \.  (0|[1-9][0-9]*)
-        ([a-z][a-z0-9-]*)?
+        (-[a-z][a-z0-9-]*)?
     $
     """,
     re.IGNORECASE | re.VERBOSE)
@@ -135,7 +135,7 @@ re_clean = re.compile(r"""
         ([0-9]+)?
     \.? ([0-9]+)?
     \.? ([0-9]+)?
-    \s* ([a-z][a-z0-9-]*)?
+    \s* (-[a-z][a-z0-9-]*)?
     $
     """,
     re.IGNORECASE | re.VERBOSE)


### PR DESCRIPTION
This would work around the current situation where plv8 install fails because of 1.1.0-beta1 in the list.
