### PR TITLE
on Python3, use the new unittest.mock from standard library

### DIFF
--- a/pgxnclient/api.py
+++ b/pgxnclient/api.py
@@ -6,7 +6,7 @@ pgxnclient -- client API stub
 
 # This file is part of the PGXN client
 
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from pgxnclient import network
 from pgxnclient.utils import load_json
@@ -14,7 +14,7 @@ from pgxnclient.errors import NetworkError, NotFound, ResourceNotFound
 from pgxnclient.utils.uri import expand_template
 
 
-class Api(object):
+class Api:
     def __init__(self, mirror):
         self.mirror = mirror
 

--- a/pgxnclient/archive.py
+++ b/pgxnclient/archive.py
@@ -34,7 +34,7 @@ def from_file(filename):
     )
 
 
-class Archive(object):
+class Archive:
     """Base class to handle archives."""
 
     def __init__(self, filename):

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -17,8 +17,6 @@ import logging
 import argparse
 from subprocess import Popen, PIPE
 
-import six
-
 from pgxnclient.utils import load_json, find_executable
 
 from pgxnclient import __version__
@@ -148,7 +146,7 @@ class CommandType(type):
         super(CommandType, cls).__init__(name, bases, dct)
 
 
-class Command(six.with_metaclass(CommandType, object)):
+class Command(metaclass=CommandType):
     """
     Base class to implement client commands.
 
@@ -254,7 +252,7 @@ class Command(six.with_metaclass(CommandType, object)):
             return True
 
         while 1:
-            ans = six.moves.input(_("%s [y/N] ") % prompt)
+            ans = input(_("%s [y/N] ") % prompt)
             if _('no').startswith(ans.lower()):
                 raise UserAbort(_("operation interrupted on user request"))
             elif _('yes').startswith(ans.lower()):
@@ -273,7 +271,7 @@ class Command(six.with_metaclass(CommandType, object)):
         try:
             return Popen(cmd, *args, **kwargs)
         except OSError as e:
-            if not isinstance(cmd, six.string_types):
+            if not isinstance(cmd, str):
                 cmd = ' '.join(cmd)
             msg = _("%s running command: %s") % (e, cmd)
             raise ProcessError(msg)
@@ -541,7 +539,7 @@ SPEC may also be an url specifying a protocol such as 'http://' or 'https://'.
         return super(WithSpecUrl, self).get_spec(**kwargs)
 
 
-class WithPgConfig(object):
+class WithPgConfig:
     """
     Mixin to implement commands that should query :program:`pg_config`.
     """
@@ -654,7 +652,7 @@ class WithMake(WithPgConfig):
             [self.get_make(), 'PG_CONFIG=%s' % self.get_pg_config()]
         )
 
-        if isinstance(cmd, six.string_types):
+        if isinstance(cmd, str):
             cmdline.append(cmd)
         else:  # a list
             cmdline.extend(cmd)
@@ -713,7 +711,7 @@ class WithMake(WithPgConfig):
         return 'gmake'
 
 
-class WithSudo(object):
+class WithSudo:
     """
     Mixin to implement commands that may invoke sudo.
     """
@@ -748,7 +746,7 @@ class WithSudo(object):
         return subp
 
 
-class WithDatabase(object):
+class WithDatabase:
     """
     Mixin to implement commands that should communicate to a database.
     """

--- a/pgxnclient/commands/info.py
+++ b/pgxnclient/commands/info.py
@@ -11,8 +11,6 @@ import logging
 import textwrap
 import xml.sax.saxutils as saxutils
 
-import six
-
 from pgxnclient import SemVer
 from pgxnclient.i18n import _, N_
 from pgxnclient.utils import emit
@@ -138,7 +136,7 @@ class Search(Command):
 
         # Convert numerical entities
         excerpt = re.sub(
-            r'\&\#(\d+)\;', lambda c: six.unichr(int(c.group(1))), excerpt
+            r'\&\#(\d+)\;', lambda c: chr(int(c.group(1))), excerpt
         )
 
         # Hilight found terms

--- a/pgxnclient/commands/install.py
+++ b/pgxnclient/commands/install.py
@@ -14,8 +14,6 @@ import logging
 import tempfile
 from subprocess import PIPE
 
-import six
-
 from pgxnclient import SemVer
 from pgxnclient import archive
 from pgxnclient import network
@@ -337,7 +335,7 @@ class LoadUnload(
             logger.debug('running sql command: "%s"', tdata)
             p = self.popen(cmdline, stdin=PIPE)
             # for Python 3: just assume default encoding will do
-            if isinstance(data, six.text_type):
+            if isinstance(data, str):
                 data = data.encode()
             p.communicate(data)
 

--- a/pgxnclient/network.py
+++ b/pgxnclient/network.py
@@ -7,9 +7,9 @@ pgxnclient -- network interaction
 # This file is part of the PGXN client
 
 import os
-from six.moves.urllib.request import build_opener
-from six.moves.urllib.error import HTTPError, URLError
-from six.moves.urllib.parse import urlsplit
+from urllib.request import build_opener
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
 from itertools import count
 from contextlib import closing
 

--- a/pgxnclient/spec.py
+++ b/pgxnclient/spec.py
@@ -9,7 +9,7 @@ pgxnclient -- specification object
 
 import os
 import re
-from six.moves.urllib.parse import unquote_plus
+from urllib.parse import unquote_plus
 import operator as _op
 
 from pgxnclient.i18n import _
@@ -19,7 +19,7 @@ from pgxnclient.utils.semver import SemVer
 from pgxnclient.utils.strings import Term
 
 
-class Spec(object):
+class Spec:
     """A name together with a range of versions."""
 
     # Available release statuses.

--- a/pgxnclient/utils/__init__.py
+++ b/pgxnclient/utils/__init__.py
@@ -6,9 +6,6 @@ pgxnclient -- misc utilities package
 
 # This file is part of the PGXN client
 
-
-from __future__ import print_function
-
 __all__ = ['emit', 'load_json', 'load_jsons', 'sha1', 'find_executable']
 
 
@@ -19,8 +16,6 @@ from collections import OrderedDict
 
 # Import the sha1 object without warnings
 from hashlib import sha1
-
-import six
 
 
 def emit(s=b'', file=None):
@@ -36,7 +31,7 @@ def emit(s=b'', file=None):
 
     enc = file.encoding or 'ascii'
 
-    if isinstance(s, six.text_type):
+    if isinstance(s, str):
         s = s.encode(enc, 'replace')
 
     # OTOH, printing bytes on Py3 to stdout/stderr will barf as well...
@@ -50,7 +45,7 @@ def emit(s=b'', file=None):
 
 def load_json(f):
     data = f.read()
-    if not isinstance(data, six.text_type):
+    if not isinstance(data, str):
         data = data.decode('utf-8')
     return load_jsons(data)
 

--- a/pgxnclient/utils/uri.py
+++ b/pgxnclient/utils/uri.py
@@ -30,8 +30,7 @@ You can also use keyword arguments for a more pythonic style::
 """
 
 import re
-import six
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 __all__ = ["expand_template", "TemplateSyntaxError"]
 
@@ -120,7 +119,7 @@ def parse_expansion(expansion):
 def percent_encode(values):
     rv = {}
     for k, v in values.items():
-        if isinstance(v, six.string_types):
+        if isinstance(v, str):
             rv[k] = quote(v)
         else:
             rv[k] = [quote(s) for s in v]
@@ -133,13 +132,13 @@ def percent_encode(values):
 #
 
 
-class _operators(object):
+class _operators:
     @staticmethod
     def opt(variables, arg, values):
         for k in variables.keys():
             v = values.get(k, None)
             if v is None or (
-                not isinstance(v, six.string_types) and len(v) == 0
+                not isinstance(v, str) and len(v) == 0
             ):
                 continue
             else:

--- a/setup.py
+++ b/setup.py
@@ -30,14 +30,12 @@ with open(os.path.join(here, 'README.rst')) as f:
     long_description = f.read()
 
 # External dependencies, depending on the Python version
-requires = ['six']
+requires = []
 setup_requires = ['pytest-runner']
-tests_require = ['mock', 'pytest']
+tests_require = ['pytest']
 
-if sys.version_info < (2, 7):
-    raise ValueError("PGXN client requires at least Python 2.7")
-if (3,) < sys.version_info < (3, 4):
-    raise ValueError("PGXN client requires at least Python 3.4")
+if sys.version_info < (3, 6):
+    raise ValueError("PGXN client requires at least Python 3.6")
 
 
 classifiers = """
@@ -47,7 +45,7 @@ Intended Audience :: Developers
 Intended Audience :: System Administrators
 License :: OSI Approved :: BSD License
 Operating System :: POSIX
-Programming Language :: Python :: 2
+Programming Language :: Python
 Programming Language :: Python :: 3
 Topic :: Database
 """
@@ -105,7 +103,7 @@ setup(
     },
     license='BSD',
     # NOTE: keep consistent with docs/install.txt
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=3.6',
     packages=find_packages(exclude=["tests"]),
     package_data={'pgxnclient': ['libexec/*']},
     entry_points={
@@ -121,5 +119,5 @@ setup(
     tests_require=tests_require,
     version=version,
     cmdclass={'build_py': CustomBuildPy},
-    extras_require={'dev': ['pytest', 'mock', 'black']},
+    extras_require={'dev': ['pytest', 'black']},
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,13 +12,5 @@ in order to correctly set up the pythonpath.
 
 import unittest
 
-
-# fix unittest maintainers stubborness: see Python issue #9424
-if unittest.TestCase.assert_ is not unittest.TestCase.assertTrue:
-    # Vaffanculo, Wolf
-    unittest.TestCase.assert_ = unittest.TestCase.assertTrue
-    unittest.TestCase.assertEquals = unittest.TestCase.assertEqual
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -12,13 +12,13 @@ class TestArchive(unittest.TestCase):
     def test_from_file_zip(self):
         fn = get_test_filename('foobar-0.42.1.zip')
         a = archive.from_file(fn)
-        self.assert_(isinstance(a, zip.ZipArchive))
+        self.assertTrue(isinstance(a, zip.ZipArchive))
         self.assertEqual(a.filename, fn)
 
     def test_from_file_tar(self):
         fn = get_test_filename('foobar-0.42.1.tar.gz')
         a = archive.from_file(fn)
-        self.assert_(isinstance(a, tar.TarArchive))
+        self.assertTrue(isinstance(a, tar.TarArchive))
         self.assertEqual(a.filename, fn)
 
     def test_from_file_unknown(self):
@@ -30,39 +30,39 @@ class TestZipArchive(unittest.TestCase):
     def test_can_open(self):
         fn = get_test_filename('foobar-0.42.1.zip')
         a = zip.ZipArchive(fn)
-        self.assert_(a.can_open())
+        self.assertTrue(a.can_open())
         a.open()
         a.close()
 
     def test_can_open_noext(self):
         fn = get_test_filename('zip.ext')
         a = zip.ZipArchive(fn)
-        self.assert_(a.can_open())
+        self.assertTrue(a.can_open())
         a.open()
         a.close()
 
     def test_cannot_open(self):
         fn = get_test_filename('foobar-0.42.1.tar.gz')
         a = zip.ZipArchive(fn)
-        self.assert_(not a.can_open())
+        self.assertTrue(not a.can_open())
 
 
 class TestTarArchive(unittest.TestCase):
     def test_can_open(self):
         fn = get_test_filename('foobar-0.42.1.tar.gz')
         a = tar.TarArchive(fn)
-        self.assert_(a.can_open())
+        self.assertTrue(a.can_open())
         a.open()
         a.close()
 
     def test_can_open_noext(self):
         fn = get_test_filename('tar.ext')
         a = tar.TarArchive(fn)
-        self.assert_(a.can_open())
+        self.assertTrue(a.can_open())
         a.open()
         a.close()
 
     def test_cannot_open(self):
         fn = get_test_filename('foobar-0.42.1.zip')
         a = tar.TarArchive(fn)
-        self.assert_(not a.can_open())
+        self.assertTrue(not a.can_open())

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,7 +3,10 @@ import shutil
 import tempfile
 import unittest
 
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 from six.moves.urllib.parse import quote
 
 from pgxnclient.tar import TarArchive

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,12 +2,8 @@ import os
 import shutil
 import tempfile
 import unittest
-
-try:
-    from unittest.mock import patch, Mock
-except ImportError:
-    from mock import patch, Mock
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
+from unittest.mock import patch, Mock
 
 from pgxnclient.tar import TarArchive
 from pgxnclient.zip import ZipArchive
@@ -19,7 +15,7 @@ from pgxnclient.errors import (
 from .testutils import ifunlink, get_test_filename
 
 
-class FakeFile(object):
+class FakeFile:
     def __init__(self, *args):
         self._f = open(*args)
         self.url = None
@@ -192,13 +188,13 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fake_get_file
 
         fn = 'foobar-0.42.1.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         from pgxnclient.cli import main
 
         try:
             main(['download', 'foobar'])
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
@@ -207,13 +203,13 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fake_get_file
 
         fn = 'foobar-0.43.2b1.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         from pgxnclient.cli import main
 
         try:
             main(['download', '--testing', 'foobar'])
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
@@ -222,7 +218,7 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fake_get_file
 
         fn = 'foobar-0.43.2b1.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         from pgxnclient.cli import main
 
@@ -233,7 +229,7 @@ class DownloadTestCase(unittest.TestCase):
                     'https://api.pgxn.org/dist/foobar/0.43.2b1/foobar-0.43.2b1.zip',
                 ]
             )
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
@@ -242,13 +238,13 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fake_get_file
 
         fn = 'pg_amqp-0.3.0.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         from pgxnclient.cli import main
 
         try:
             main(['download', 'amqp'])
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
@@ -261,7 +257,7 @@ class DownloadTestCase(unittest.TestCase):
         fn2 = 'foobar-0.42.1-2.zip'
 
         for tmp in (fn, fn1, fn2):
-            self.assert_(not os.path.exists(tmp))
+            self.assertTrue(not os.path.exists(tmp))
 
         try:
             f = open(fn, "w")
@@ -271,14 +267,14 @@ class DownloadTestCase(unittest.TestCase):
             from pgxnclient.cli import main
 
             main(['download', 'foobar'])
-            self.assert_(os.path.exists(fn1))
-            self.assert_(not os.path.exists(fn2))
+            self.assertTrue(os.path.exists(fn1))
+            self.assertTrue(not os.path.exists(fn2))
 
             main(['download', 'foobar'])
-            self.assert_(os.path.exists(fn2))
+            self.assertTrue(os.path.exists(fn2))
 
             f = open(fn)
-            self.assertEquals(f.read(), 'test')
+            self.assertEqual(f.read(), 'test')
             f.close()
 
         finally:
@@ -299,7 +295,7 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fakefake
 
         fn = 'foobar-0.42.1.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         try:
             from pgxnclient.cli import main
@@ -307,7 +303,7 @@ class DownloadTestCase(unittest.TestCase):
 
             self.assertRaises(BadChecksum, main, ['download', 'foobar'])
 
-            self.assert_(not os.path.exists(fn))
+            self.assertTrue(not os.path.exists(fn))
 
         finally:
             ifunlink(fn)
@@ -317,19 +313,19 @@ class DownloadTestCase(unittest.TestCase):
         mock.side_effect = fake_get_file
 
         fn = 'pyrseas-0.4.1.zip'
-        self.assert_(not os.path.exists(fn))
+        self.assertTrue(not os.path.exists(fn))
 
         from pgxnclient.cli import main
 
         try:
             main(['download', 'pyrseas'])
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
         try:
             main(['download', 'Pyrseas'])
-            self.assert_(os.path.exists(fn))
+            self.assertTrue(os.path.exists(fn))
         finally:
             ifunlink(fn)
 
@@ -438,7 +434,7 @@ class DownloadTestCase(unittest.TestCase):
             self.assertEqual(res, cmd.get_best_version(data, spec))
 
 
-class Assertions(object):
+class Assertions:
 
     make = object()
 
@@ -484,7 +480,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--sudo', '--', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -506,7 +502,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -528,7 +524,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
             ]
         )
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -546,7 +542,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         self.assertRaises(PgxnClientException, main, ['install', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 1)
+        self.assertEqual(self.mock_popen.call_count, 1)
 
     def test_install_bad_sha1(self):
         def fakefake(url):
@@ -575,7 +571,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--nosudo', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -588,7 +584,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--sudo', 'gksudo -d "hello world"', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -606,7 +602,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--sudo', '--', fn])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -615,7 +611,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
         )
         make_cwd = self.mock_popen.call_args_list[1][1]['cwd']
 
-        self.assertEquals(mock_unpack.call_count, 1)
+        self.assertEqual(mock_unpack.call_count, 1)
         (tmpdir,) = mock_unpack.call_args[0]
         self.assertEqual(make_cwd, os.path.join(tmpdir, 'foobar-0.42.1'))
 
@@ -628,7 +624,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--sudo', '--', fn])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -637,7 +633,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
         )
         make_cwd = self.mock_popen.call_args_list[1][1]['cwd']
 
-        self.assertEquals(mock_unpack.call_count, 1)
+        self.assertEqual(mock_unpack.call_count, 1)
         (tmpdir,) = mock_unpack.call_args[0]
         self.assertEqual(make_cwd, os.path.join(tmpdir, 'foobar-0.42.1'))
 
@@ -649,7 +645,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
 
         main(['install', '--sudo', '--', url])
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -673,7 +669,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 2)
+        self.assertEqual(self.mock_popen.call_count, 2)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -681,7 +677,7 @@ class InstallTestCase(unittest.TestCase, Assertions):
         self.assertCallArgs(
             ['sudo', self.make], self.mock_popen.call_args_list[1][0][0][:2]
         )
-        self.assertEquals(dir, self.mock_popen.call_args_list[1][1]['cwd'])
+        self.assertEqual(dir, self.mock_popen.call_args_list[1][1]['cwd'])
 
 
 class CheckTestCase(unittest.TestCase, Assertions):
@@ -708,7 +704,7 @@ class CheckTestCase(unittest.TestCase, Assertions):
 
         main(['check', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 1)
+        self.assertEqual(self.mock_popen.call_count, 1)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -723,7 +719,7 @@ class CheckTestCase(unittest.TestCase, Assertions):
             ]
         )
 
-        self.assertEquals(self.mock_popen.call_count, 1)
+        self.assertEqual(self.mock_popen.call_count, 1)
         self.assertCallArgs(
             [self.make], self.mock_popen.call_args_list[0][0][0][:1]
         )
@@ -735,7 +731,7 @@ class CheckTestCase(unittest.TestCase, Assertions):
 
         self.assertRaises(PgxnClientException, main, ['check', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 1)
+        self.assertEqual(self.mock_popen.call_count, 1)
 
     def test_check_diff_moved(self):
         def create_regression_files(*args, **kwargs):
@@ -747,11 +743,11 @@ class CheckTestCase(unittest.TestCase, Assertions):
         self.mock_popen.side_effect = create_regression_files
         self.mock_popen.return_value.returncode = 1
 
-        self.assert_(
+        self.assertTrue(
             not os.path.exists('regression.out'),
             "Please remove temp file 'regression.out' from current dir",
         )
-        self.assert_(
+        self.assertTrue(
             not os.path.exists('regression.diffs'),
             "Please remove temp file 'regression.diffs' from current dir",
         )
@@ -760,9 +756,9 @@ class CheckTestCase(unittest.TestCase, Assertions):
 
         try:
             self.assertRaises(PgxnClientException, main, ['check', 'foobar'])
-            self.assertEquals(self.mock_popen.call_count, 1)
-            self.assert_(os.path.exists('regression.out'))
-            self.assert_(os.path.exists('regression.diffs'))
+            self.assertEqual(self.mock_popen.call_count, 1)
+            self.assertTrue(os.path.exists('regression.out'))
+            self.assertTrue(os.path.exists('regression.diffs'))
         finally:
             ifunlink('regression.out')
             ifunlink('regression.diffs')
@@ -784,7 +780,7 @@ class CheckTestCase(unittest.TestCase, Assertions):
 
         self.assertRaises(BadChecksum, main, ['check', 'foobar'])
 
-        self.assertEquals(self.mock_popen.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 0)
 
 
 class LoadTestCase(unittest.TestCase):
@@ -813,11 +809,11 @@ class LoadTestCase(unittest.TestCase):
         from pgxnclient.commands.install import Load
 
         cmd = Load(None)
-        self.assertEquals((9, 0, 3), cmd.parse_pg_version('90003'))
-        self.assertEquals((9, 1, 0), cmd.parse_pg_version('90100'))
-        self.assertEquals((10, 0), cmd.parse_pg_version('100000'))
-        self.assertEquals((13, 2), cmd.parse_pg_version('130002'))
-        self.assertEquals((13, 2), cmd.parse_pg_version('130002\n'))
+        self.assertEqual((9, 0, 3), cmd.parse_pg_version('90003'))
+        self.assertEqual((9, 1, 0), cmd.parse_pg_version('90100'))
+        self.assertEqual((10, 0), cmd.parse_pg_version('100000'))
+        self.assertEqual((13, 2), cmd.parse_pg_version('130002'))
+        self.assertEqual((13, 2), cmd.parse_pg_version('130002\n'))
 
     @patch('pgxnclient.network.get_file')
     def test_check_psql_options(self, mock_get):
@@ -852,11 +848,11 @@ class LoadTestCase(unittest.TestCase):
 
         main(['load', '--yes', get_test_filename('foobar-0.42.1.zip')])
 
-        self.assertEquals(mock_unpack.call_count, 0)
-        self.assertEquals(self.mock_popen.call_count, 1)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(mock_unpack.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 1)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args[0][0], b'CREATE EXTENSION foobar;'
         )
 
@@ -870,11 +866,11 @@ class LoadTestCase(unittest.TestCase):
 
         main(['load', '--yes', get_test_filename('foobar-0.42.1.tar.gz')])
 
-        self.assertEquals(mock_unpack.call_count, 0)
-        self.assertEquals(self.mock_popen.call_count, 1)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(mock_unpack.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 1)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args[0][0], b'CREATE EXTENSION foobar;'
         )
 
@@ -895,10 +891,10 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 1)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(self.mock_popen.call_count, 1)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args[0][0], b'CREATE EXTENSION foobar;'
         )
 
@@ -918,11 +914,11 @@ class LoadTestCase(unittest.TestCase):
             ]
         )
 
-        self.assertEquals(mock_unpack.call_count, 0)
-        self.assertEquals(self.mock_popen.call_count, 1)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(mock_unpack.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 1)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args[0][0], b'CREATE EXTENSION foobar;'
         )
 
@@ -936,11 +932,11 @@ class LoadTestCase(unittest.TestCase):
 
         main(['load', '--yes', 'https://example.org/foobar-0.42.1.tar.gz'])
 
-        self.assertEquals(mock_unpack.call_count, 0)
-        self.assertEquals(self.mock_popen.call_count, 1)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(mock_unpack.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 1)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args[0][0], b'CREATE EXTENSION foobar;'
         )
 
@@ -962,19 +958,19 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 4)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(self.mock_popen.call_count, 4)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[0][0][0], b'CREATE EXTENSION foo;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[1][0][0], b'CREATE EXTENSION bar;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[2][0][0], b'CREATE EXTENSION baz;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[3][0][0], b'CREATE EXTENSION qux;'
         )
 
@@ -996,19 +992,19 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 4)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(self.mock_popen.call_count, 4)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[0][0][0], b'DROP EXTENSION qux;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[1][0][0], b'DROP EXTENSION baz;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[2][0][0], b'DROP EXTENSION bar;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[3][0][0], b'DROP EXTENSION foo;'
         )
 
@@ -1030,13 +1026,13 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 2)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(self.mock_popen.call_count, 2)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[0][0][0], b'CREATE EXTENSION baz;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[1][0][0], b'CREATE EXTENSION foo;'
         )
 
@@ -1058,13 +1054,13 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 2)
-        self.assert_('psql' in self.mock_popen.call_args[0][0][0])
+        self.assertEqual(self.mock_popen.call_count, 2)
+        self.assertTrue('psql' in self.mock_popen.call_args[0][0][0])
         communicate = self.mock_popen.return_value.communicate
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[0][0][0], b'DROP EXTENSION baz;'
         )
-        self.assertEquals(
+        self.assertEqual(
             communicate.call_args_list[1][0][0], b'DROP EXTENSION foo;'
         )
 
@@ -1088,7 +1084,7 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 0)
 
     def test_unload_missing(self):
         tdir = tempfile.mkdtemp()
@@ -1112,7 +1108,7 @@ class LoadTestCase(unittest.TestCase):
         finally:
             shutil.rmtree(tdir)
 
-        self.assertEquals(self.mock_popen.call_count, 0)
+        self.assertEqual(self.mock_popen.call_count, 0)
 
     def test_missing_meta_dir(self):
         # issue #19

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -13,8 +13,8 @@ class LabelTestCase(unittest.TestCase):
         ]:
             self.assertEqual(Label(s), s)
             self.assertEqual(Label(s), Label(s))
-            self.assert_(Label(s) <= Label(s))
-            self.assert_(Label(s) >= Label(s))
+            self.assertTrue(Label(s) <= Label(s))
+            self.assertTrue(Label(s) >= Label(s))
 
     def test_bad(self):
         def ar(s):
@@ -42,14 +42,14 @@ class LabelTestCase(unittest.TestCase):
         self.assertNotEqual(str(Label('a')), str(Label('A')))  # preserving
 
     def test_order(self):
-        self.assert_(Label('a') < Label('B') < Label('c'))
-        self.assert_(Label('A') < Label('b') < Label('C'))
-        self.assert_(Label('a') <= Label('B') <= Label('c'))
-        self.assert_(Label('A') <= Label('b') <= Label('C'))
-        self.assert_(Label('c') > Label('B') > Label('a'))
-        self.assert_(Label('C') > Label('b') > Label('A'))
-        self.assert_(Label('c') >= Label('B') >= Label('a'))
-        self.assert_(Label('C') >= Label('b') >= Label('A'))
+        self.assertTrue(Label('a') < Label('B') < Label('c'))
+        self.assertTrue(Label('A') < Label('b') < Label('C'))
+        self.assertTrue(Label('a') <= Label('B') <= Label('c'))
+        self.assertTrue(Label('A') <= Label('b') <= Label('C'))
+        self.assertTrue(Label('c') > Label('B') > Label('a'))
+        self.assertTrue(Label('C') > Label('b') > Label('A'))
+        self.assertTrue(Label('c') >= Label('B') >= Label('a'))
+        self.assertTrue(Label('C') >= Label('b') >= Label('A'))
 
 
 class TermTestCase(unittest.TestCase):
@@ -57,8 +57,8 @@ class TermTestCase(unittest.TestCase):
         for s in ['aa' 'adfkjh"()']:
             self.assertEqual(Term(s), s)
             self.assertEqual(Term(s), Term(s))
-            self.assert_(Term(s) <= Term(s))
-            self.assert_(Term(s) >= Term(s))
+            self.assertTrue(Term(s) <= Term(s))
+            self.assertTrue(Term(s) >= Term(s))
 
     def test_bad(self):
         def ar(s):

--- a/tests/test_semver.py
+++ b/tests/test_semver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 from pgxnclient import SemVer
@@ -61,10 +59,10 @@ class SemVerTestCase(unittest.TestCase):
         ]:
             self.assertEqual(SemVer(s1), SemVer(s2))
             self.assertEqual(hash(SemVer(s1)), hash(SemVer(s2)))
-            self.assert_(
+            self.assertTrue(
                 SemVer(s1) <= SemVer(s2), "%s <= %s failed" % (s1, s2)
             )
-            self.assert_(
+            self.assertTrue(
                 SemVer(s1) >= SemVer(s2), "%s >= %s failed" % (s1, s2)
             )
 
@@ -93,14 +91,14 @@ class SemVerTestCase(unittest.TestCase):
             ('2.2.2-rc-2', '2.2.2-RC-1'),
             ('0.9.10', '0.9.9'),
         ]:
-            self.assert_(
+            self.assertTrue(
                 SemVer(s1) >= SemVer(s2), "%s >= %s failed" % (s1, s2)
             )
-            self.assert_(SemVer(s1) > SemVer(s2), "%s > %s failed" % (s1, s2))
-            self.assert_(
+            self.assertTrue(SemVer(s1) > SemVer(s2), "%s > %s failed" % (s1, s2))
+            self.assertTrue(
                 SemVer(s2) <= SemVer(s1), "%s <= %s failed" % (s2, s1)
             )
-            self.assert_(SemVer(s2) < SemVer(s1), "%s < %s failed" % (s2, s1))
+            self.assertTrue(SemVer(s2) < SemVer(s1), "%s < %s failed" % (s2, s1))
 
     def test_clean(self):
         for s1, s2 in [

--- a/tests/testdata/download.py
+++ b/tests/testdata/download.py
@@ -5,8 +5,8 @@ The files downloaded are used by the test suite.
 """
 import os
 import sys
-from six.moves.urllib.parse import quote
-from six.moves.urllib.request import urlopen
+from urllib.parse import quote
+from urllib.request import urlopen
 
 if __name__ == '__main__':
     url = sys.argv[1]


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
